### PR TITLE
Feature/configure timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ An Ansible role for installing Open Trip Planner
 - `otp_process_mem` - JVM maximum memory, passed directly to the JVM -Xmx option (default: `3G`, e.g. 3 gigabytes)
 - `otp_web_port` - Port to serve the OTP webapp/API on (default: `8080`)
 - `upstart_start_on` - Upstart job, passed directly to 'start on' (default: `(filesystem and net-device-up IFACE=lo)`)
-- `otp_session_timeout` - Number of seconds before OTP requests time out (default: 30)
+- `otp_session_timeout_s` - Number of seconds before OTP requests time out (default: 30)
 
 ## Example Playbook
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ An Ansible role for installing Open Trip Planner
 - `otp_process_mem` - JVM maximum memory, passed directly to the JVM -Xmx option (default: `3G`, e.g. 3 gigabytes)
 - `otp_web_port` - Port to serve the OTP webapp/API on (default: `8080`)
 - `upstart_start_on` - Upstart job, passed directly to 'start on' (default: `(filesystem and net-device-up IFACE=lo)`)
+- `otp_session_timeout` - Number of seconds before OTP requests time out (default: 30)
 
 ## Example Playbook
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,6 +7,10 @@
        dest={{ otp_bin_dir }}
        version={{ otp_version }}
 
+- name: Set OpenTripPlanner Session Timeout
+  lineinfile: dest={{ otp_bin_dir }}/src/client/WEB-INF/web.xml regexp="(^|\W)<session-timeout>30</session-timeout>$" line="\t\t<session-timeout>{{ otp_session_timeout }}</session-timeout>"
+  when: otp_session_timeout is defined
+
 - name: Compile OpenTripPlanner
   command: mvn clean package -DskipTests
            chdir={{ otp_bin_dir }}

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,7 @@
 ---
+- name: Stop OpenTripPlanner
+  service: name=otp state=stopped
+
 - name: Install maven
   apt: pkg=maven state=present
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,8 +11,8 @@
        version={{ otp_version }}
 
 - name: Set OpenTripPlanner Session Timeout
-  lineinfile: dest={{ otp_bin_dir }}/src/client/WEB-INF/web.xml regexp="(^|\W)<session-timeout>30</session-timeout>$" line="\t\t<session-timeout>{{ otp_session_timeout }}</session-timeout>"
-  when: otp_session_timeout is defined
+  lineinfile: dest={{ otp_bin_dir }}/src/client/WEB-INF/web.xml regexp="(^|\W)<session-timeout>30</session-timeout>$" line="\t\t<session-timeout>{{ otp_session_timeout_s }}</session-timeout>"
+  when: otp_session_timeout_s is defined
 
 - name: Compile OpenTripPlanner
   command: mvn clean package -DskipTests

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,11 @@
 ---
+- name: Check if OpenTripPlanner service exists
+  stat: path=/etc/init/otp.conf
+  register: otp_service
+
 - name: Stop OpenTripPlanner
   service: name=otp state=stopped
+  when: otp_service.stat.exists
 
 - name: Install maven
   apt: pkg=maven state=present
@@ -10,8 +15,10 @@
        dest={{ otp_bin_dir }}
        version={{ otp_version }}
 
-- name: Set OpenTripPlanner Session Timeout
-  lineinfile: dest={{ otp_bin_dir }}/src/client/WEB-INF/web.xml regexp="(^|\W)<session-timeout>30</session-timeout>$" line="\t\t<session-timeout>{{ otp_session_timeout_s }}</session-timeout>"
+- name: Set OpenTripPlanner session timeout
+  lineinfile: dest={{ otp_bin_dir }}/src/client/WEB-INF/web.xml
+              regexp="(^|\W)<session-timeout>30</session-timeout>$"
+              line="\t\t<session-timeout>{{ otp_session_timeout_s }}</session-timeout>"
   when: otp_session_timeout_s is defined
 
 - name: Compile OpenTripPlanner


### PR DESCRIPTION
Change session timeout in config file before OTP compilation.

Also stop `otp` upstart service at start of task, to prevent out-of-memory errors when attempting to compile on reprovision.
