### PR TITLE
Update to OpenTripPlanner 0.20.0; Use Java 8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .vagrant
+*.retry
 
 examples/roles/azavea.git
 examples/roles/azavea.java

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.0
+
+- Use OpenTripPlanner precopiled JARs
+
 ## 0.3.2
 
  - Allow for session timeout configuration

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ An Ansible role for installing Open Trip Planner
 - `otp_user` - OTP default user (default: `opentripplanner`)
 - `otp_process_mem` - JVM maximum memory, passed directly to the JVM -Xmx option (default: `3G`, e.g. 3 gigabytes)
 - `otp_web_port` - Port to serve the OTP webapp/API on (default: `8080`)
-- `upstart_start_on` - Upstart job, passed directly to 'start on' (default: `(filesystem and net-device-up IFACE=lo)`)
+- `otp_upstart_start_on` - Upstart job, passed directly to 'start on' (default: `(filesystem and net-device-up IFACE=lo)`)
 
 ## Example Playbook
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,7 +2,9 @@
 otp_bin_dir: /opt/opentripplanner
 otp_data_dir: /var/otp
 otp_user: opentripplanner
-otp_version: 0.15.0
-upstart_start_on: '(filesystem and net-device-up IFACE=lo)'
+otp_version: "0.20.0"
+otp_jar_suffix: "-shaded"
+otp_jar_sha1: "46f2b665cda68ecf529e8aef00c74e6a67c635a5"
 otp_process_mem: 3G
 otp_web_port: 8080
+otp_upstart_start_on: "(local-filesystems and net-device-up IFACE!=lo)"

--- a/examples/Vagrantfile
+++ b/examples/Vagrantfile
@@ -7,7 +7,7 @@ VAGRANTFILE_API_VERSION = "2"
 if [ "up", "provision" ].include?(ARGV.first) && File.directory?("roles") &&
   !(File.directory?("roles/azavea.git") || File.symlink?("roles/azavea.git")) ||
   !(File.directory?("roles/azavea.java") || File.symlink?("roles/azavea.java"))
-  system("ansible-galaxy install --force -r roles.txt -p roles")
+  system("ansible-galaxy install --force -r roles.yml -p roles")
 end
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|

--- a/examples/roles.txt
+++ b/examples/roles.txt
@@ -1,2 +1,0 @@
-azavea.git,0.1.0
-azavea.java,0.1.1

--- a/examples/roles.yml
+++ b/examples/roles.yml
@@ -1,0 +1,5 @@
+- src: azavea.git
+  version: 0.1.0
+
+- src: azavea.java
+  version: 0.2.6

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -5,7 +5,7 @@ galaxy_info:
   description: An Ansible role for installing Open Trip Planner.
   company: Azavea Inc.
   license: Apache
-  min_ansible_version: 1.5
+  min_ansible_version: 2.0
   platforms:
   - name: Ubuntu
     versions:
@@ -15,4 +15,8 @@ galaxy_info:
 
 dependencies:
   - { role: "azavea.git" }
-  - { role: "azavea.java" }
+  - role: "azavea.java"
+    java_flavor: "oracle"
+    java_major_version: "8"
+    java_version: "8u92*"
+    java_oracle_accept_license_agreement: True

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,9 +10,13 @@
 - name: Create OpenTripPlanner binary directory
   file: path={{ otp_bin_dir }} mode=0775 state=directory
 
+- name: Store derived jarfile name for convenience
+  set_fact: otp_jar_name=otp-{{ otp_version }}{{ otp_jar_suffix }}.jar
+
 - name: Download OpenTripPlanner
-  get_url: url=http://maven.conveyal.com.s3.amazonaws.com/org/opentripplanner/otp/{{ otp_version }}/otp-{{ otp_version }}.jar
-           dest={{ otp_bin_dir }}
+  get_url: url=http://maven.conveyal.com.s3.amazonaws.com/org/opentripplanner/otp/{{ otp_version }}/{{ otp_jar_name }}
+           dest={{ otp_bin_dir }}/{{ otp_jar_name }}
+           checksum=sha1:{{ otp_jar_sha1 }}
            mode=0775
 
 - name: Create service account for OpenTripPlanner
@@ -27,4 +31,5 @@
 
 - name: Install upstart service
   template: src=otp.conf.j2 dest=/etc/init/otp.conf
-  notify: Restart OpenTripPlanner
+  notify:
+    - Restart OpenTripPlanner

--- a/templates/otp.conf.j2
+++ b/templates/otp.conf.j2
@@ -1,13 +1,14 @@
 ## NOTICE: This file is written by ansible, and any changes made here will be overwritten on next provision.
 #           Modify azavea.opentripplanner/templates/otp.conf.j2 to make changes stick.
-description "start OpenTripPlanner process"
+description "OpenTripPlanner"
 
-start on {{ upstart_start_on }}
-stop on runlevel [!2345]
+start on {{ otp_upstart_start_on }}
+stop on shutdown
 
+respawn
 setuid {{ otp_user }}
-
 chdir {{ otp_bin_dir }}
+
 script
-    exec /usr/bin/java -Xmx{{otp_process_mem}} -jar {{ otp_bin_dir }}/otp-{{ otp_version }}.jar --server --analyst --port {{ otp_web_port }} --graphs {{ otp_data_dir }}
+    exec /usr/bin/java -Xmx{{otp_process_mem}} -jar {{ otp_bin_dir }}/{{ otp_jar_name }} --server --analyst --port {{ otp_web_port }} --graphs {{ otp_data_dir }}
 end script


### PR DESCRIPTION
Add support for installing OpenTripPlanner 0.20.0, and in the process upgrade to Java 8.

A backwards incompatible change was introduced in the renaming of an attribute to from `upstart_start_on` to `otp_upstart_start_on`.

Intended to supercede https://github.com/azavea/ansible-opentripplanner/pull/15.

---

**Testing**

Ensure that the example project provisions cleanly, then interact with the OpenTripPlanner UI via [http://localhost:8080/](http://localhost:8080/):

``` bash
$ cd examples
$ vagrant up
```
