### PR TITLE
Update default release version

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ An Ansible role for installing Open Trip Planner
 
 - `otp_bin_dir` - Local directory to install OTP (default: `/opt/opentripplanner`)
 - `otp_data_dir` - Local directory to store OTP data (default: `/var/otp`)
-- `otp_version` - Commit to pull from (default: 0.15 release)
+- `otp_version` - Commit to pull from (default: 1.0 release)
 - `otp_user` - OTP default user (default: `opentripplanner`)
 - `otp_process_mem` - JVM maximum memory, passed directly to the JVM -Xmx option (default: `3G`, e.g. 3 gigabytes)
 - `otp_web_port` - Port to serve the OTP webapp/API on (default: `8080`)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,9 +2,9 @@
 otp_bin_dir: /opt/opentripplanner
 otp_data_dir: /var/otp
 otp_user: opentripplanner
-otp_version: "0.20.0"
+otp_version: "1.0.0"
 otp_jar_suffix: "-shaded"
-otp_jar_sha1: "46f2b665cda68ecf529e8aef00c74e6a67c635a5"
+otp_jar_sha1: "aeed6df0e72b331fd2ea18ea03651384fa83e534"
 otp_process_mem: 3G
 otp_web_port: 8080
 otp_upstart_start_on: "(local-filesystems and net-device-up IFACE!=lo)"


### PR DESCRIPTION
Update to 1.0 release.

New release includes fixes for routing with waypoints, which are needed for azavea/cac-tripplanner#495.
