### PR TITLE
Bump java package and OpenTripPlanner versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.0.5
+
+- Bump default version of OpenTripPlanner to 1.1.0.
+- Bump version of anisible-java role to 0.4.0 in example.
+
 ## 1.0.4
 
 - Bump version of JVM to `8u121*`.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ An Ansible role for installing Open Trip Planner
 
 - `otp_bin_dir` - Local directory to install OTP (default: `/opt/opentripplanner`)
 - `otp_data_dir` - Local directory to store OTP data (default: `/var/otp`)
-- `otp_version` - Commit to pull from (default: 1.0 release)
+- `otp_version` - Commit to pull from (default: 1.1.0 release)
 - `otp_user` - OTP default user (default: `opentripplanner`)
 - `otp_process_mem` - JVM maximum memory, passed directly to the JVM -Xmx option (default: `3G`, e.g. 3 gigabytes)
 - `otp_web_port` - Port to serve the OTP webapp/API on (default: `8080`)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,9 +2,9 @@
 otp_bin_dir: /opt/opentripplanner
 otp_data_dir: /var/otp
 otp_user: opentripplanner
-otp_version: "1.0.0"
+otp_version: "1.1.0"
 otp_jar_suffix: "-shaded"
-otp_jar_sha1: "aeed6df0e72b331fd2ea18ea03651384fa83e534"
+otp_jar_sha1: "93565cd039726b607db3f07d690000c44e7f97d5"
 otp_process_mem: 3G
 otp_web_port: 8080
 otp_upstart_start_on: "(local-filesystems and net-device-up IFACE!=lo)"

--- a/examples/roles.yml
+++ b/examples/roles.yml
@@ -2,4 +2,4 @@
   version: 0.1.0
 
 - src: azavea.java
-  version: 0.2.6
+  version: 0.4.0

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -18,5 +18,5 @@ dependencies:
   - role: "azavea.java"
     java_flavor: "oracle"
     java_major_version: "8"
-    java_version: "8u121*"
+    java_version: "8u131*"
     java_oracle_accept_license_agreement: True

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,7 +14,7 @@
   set_fact: otp_jar_name=otp-{{ otp_version }}{{ otp_jar_suffix }}.jar
 
 - name: Download OpenTripPlanner
-  get_url: url=http://maven.conveyal.com.s3.amazonaws.com/org/opentripplanner/otp/{{ otp_version }}/{{ otp_jar_name }}
+  get_url: url=https://repo1.maven.org/maven2/org/opentripplanner/otp/{{ otp_version }}/{{ otp_jar_name }}
            dest={{ otp_bin_dir }}/{{ otp_jar_name }}
            checksum=sha1:{{ otp_jar_sha1 }}
            mode=0775


### PR DESCRIPTION
Previous Java package [no longer available](https://launchpad.net/~webupd8team/+archive/ubuntu/java).

Update OTP minor version to 1.1.0, which was released March 15, 2017. Updated location for pre-compiled OTP jar download, as documented [here](http://docs.opentripplanner.org/en/latest/Getting-OTP/#pre-built-jars).