### PR TITLE
Bump default OTP version to 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 1.0.7
 
 - Bump default version of OpenTripPlanner to 1.2.0.
+- Bump default version of JVM to `8u151*`.
 
 ## 1.0.6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.7
+
+- Bump default version of OpenTripPlanner to 1.2.0.
+
 ## 1.0.6
 
 - Bump default version of JVM to `8u144*`.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,9 +2,9 @@
 otp_bin_dir: /opt/opentripplanner
 otp_data_dir: /var/otp
 otp_user: opentripplanner
-otp_version: "1.1.0"
+otp_version: "1.2.0"
 otp_jar_suffix: "-shaded"
-otp_jar_sha1: "93565cd039726b607db3f07d690000c44e7f97d5"
+otp_jar_sha1: "a7f659a63a54e894457bab6fc162fb0f47586057"
 otp_process_mem: 3G
 otp_web_port: 8080
 otp_upstart_start_on: "(local-filesystems and net-device-up IFACE!=lo)"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -18,5 +18,5 @@ dependencies:
   - role: "azavea.java"
     java_flavor: "oracle"
     java_major_version: "8"
-    java_version: "8u144*"
+    java_version: "8u151*"
     java_oracle_accept_license_agreement: True


### PR DESCRIPTION
- Bump OTP version to 1.2.0, which was released August 17th, 2017. This version is already in use by azavea/cac-tripplanner.

- Bump JVM package to that listed [here](https://launchpad.net/~webupd8team/+archive/ubuntu/java?field.series_filter=trusty); previous package no longer available 
