### PR TITLE
Unpin JAVA version

### DIFF
--- a/examples/site.yml
+++ b/examples/site.yml
@@ -7,7 +7,7 @@
 
   vars:
     java_major_version: "8"
-    java_version: "8u161*"
+    java_version: "8u*"
 
   roles:
     - { role: "azavea.opentripplanner" }

--- a/examples/site.yml
+++ b/examples/site.yml
@@ -5,5 +5,9 @@
     - name: Update APT cache
       apt: update_cache=yes
 
+  vars:
+    java_major_version: "8"
+    java_version: "8u161*"
+
   roles:
     - { role: "azavea.opentripplanner" }

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -17,6 +17,4 @@ dependencies:
   - { role: "azavea.git" }
   - role: "azavea.java"
     java_flavor: "oracle"
-    java_major_version: "8"
-    java_version: "8u161*"
     java_oracle_accept_license_agreement: True


### PR DESCRIPTION
# Overview

Allow users to specify their own `java_version` and `java_major_version` so that installation doesn't break when WebUpd8 updates the Java installer PPA

Fixes #29 

# Testing
- See the **Example Playbook** section of the [README](https://github.com/azavea/ansible-opentripplanner#example-playbook)
- See azavea/cac-tripplanner#1027