### PR TITLE
Bump default version to 1.3.0

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,9 +2,9 @@
 otp_bin_dir: /opt/opentripplanner
 otp_data_dir: /var/otp
 otp_user: opentripplanner
-otp_version: "1.2.0"
+otp_version: "1.3.0"
 otp_jar_suffix: "-shaded"
-otp_jar_sha1: "a7f659a63a54e894457bab6fc162fb0f47586057"
+otp_jar_sha1: "7719d90f4b33bd877b85fb63db66820637b5612f"
 otp_process_mem: 3G
 otp_web_port: 8080
 otp_upstart_start_on: "(local-filesystems and net-device-up IFACE!=lo)"


### PR DESCRIPTION
Use [newer release of OpenTripPlanner](https://github.com/opentripplanner/OpenTripPlanner/releases) by default.

Closes #31.